### PR TITLE
 Add PKG_CXXFLAGS to Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,6 +1,7 @@
 ## Use the R_HOME indirection to support installations of multiple R version
 PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"`
 CXX_STD = CXX11
+PKG_CXXFLAGS = -std=c++11
 ## As an alternative, one can also add this code in a file 'configure'
 ##
 ##    PKG_LIBS=`${R_HOME}/bin/Rscript -e "Rcpp:::LdFlags()"`


### PR DESCRIPTION
Setting the PKG_CXXFLAGS flag to -std=c++11 allows Rcpp to correctly use the c++11 standard in Linux Mint. I'm not really sure why the c++11 flag that's there already isn't recognized, but this fixes the problem. I see absolutely no reason why this change should cause any problem on any other system, but maybe someone should at least build with it on a Mac before this gets merged in.
