### PR TITLE
Optimizing CreateCohort.sql

### DIFF
--- a/inst/sql/sql_server/CreateCohorts.sql
+++ b/inst/sql/sql_server/CreateCohorts.sql
@@ -82,15 +82,17 @@ FROM (
 		(SELECT person_id,
 						COUNT(DISTINCT(drug_concept_id)) drug_count
 			 FROM @exposure_database_schema.@exposure_table
-			 WHERE drug_concept_id IN (@target_id, @comparator_id))
+			 WHERE drug_concept_id IN (@target_id, @comparator_id)
 			 GROUP BY person_id) temp
 		ON
 			exposure_table.person_id = temp.person_id
 		WHERE
 			temp.drug_count = 1
+			AND
 	} : {
-		WHERE drug_concept_id IN (@target_id, @comparator_id)
+		WHERE
 	}
+	exposure_table.drug_concept_id IN (@target_id, @comparator_id)
 } : {
 	SELECT exposure_table.subject_id,
 {@cdm_version == "4"} ? {
@@ -112,9 +114,11 @@ FROM (
 				exposure_table.subject_id = temp.subject_id
 			WHERE
 				temp.cohort_count = 1
+				AND
 		} : {
-			WHERE cohort_concept_id IN (@target_id, @comparator_id)
+			WHERE
 		}
+		  cohort_concept_id IN (@target_id, @comparator_id)
 	} : {
 		{@remove_duplicate_subjects} ? {
 			INNER JOIN
@@ -126,9 +130,11 @@ FROM (
 				exposure_table.subject_id = temp.subject_id
 			WHERE
 				temp.cohort_count = 1
+				AND
 		} : {
-			WHERE cohort_definition_id IN (@target_id, @comparator_id)
+			WHERE
 		}
+		cohort_definition_id IN (@target_id, @comparator_id)
 	}
 }
 	) raw_cohorts

--- a/inst/sql/sql_server/CreateCohorts.sql
+++ b/inst/sql/sql_server/CreateCohorts.sql
@@ -32,35 +32,35 @@ limitations under the License.
 
 IF OBJECT_ID('tempdb..#cohort_person', 'U') IS NOT NULL
 	DROP TABLE #cohort_person;
-	
+
 SELECT ROW_NUMBER() OVER (ORDER BY person_id, cohort_start_date) AS row_id,
 	subject_id,
-{@cdm_version == "4"} ? {	
+{@cdm_version == "4"} ? {
 	cohort_definition_id AS cohort_concept_id,
 } : {
 	cohort_definition_id,
 }
 	cohort_start_date,
 	DATEDIFF(DAY, observation_period_start_date, cohort_start_date) AS days_from_obs_start,
-	{@study_end_date != '' } ? { 
-	    CASE 
+	{@study_end_date != '' } ? {
+	    CASE
 			WHEN cohort_end_date <= CAST('@study_end_date' AS DATE)
-				THEN DATEDIFF(DAY, cohort_start_date, cohort_end_date) 
-			ELSE 
+				THEN DATEDIFF(DAY, cohort_start_date, cohort_end_date)
+			ELSE
 				DATEDIFF(DAY, cohort_start_date, CAST('@study_end_date' AS DATE))
-		END 
+		END
 	} : {
 		DATEDIFF(DAY, cohort_start_date, cohort_end_date)
 	} AS days_to_cohort_end,
-	{@study_end_date != '' } ? { 
-	    CASE 
+	{@study_end_date != '' } ? {
+	    CASE
 			WHEN observation_period_end_date <= CAST('@study_end_date' AS DATE)
-				THEN DATEDIFF(DAY, cohort_start_date, observation_period_end_date) 
-			ELSE 
+				THEN DATEDIFF(DAY, cohort_start_date, observation_period_end_date)
+			ELSE
 				DATEDIFF(DAY, cohort_start_date, CAST('@study_end_date' AS DATE))
-		END 
+		END
 	} : {
-		DATEDIFF(DAY, cohort_start_date, observation_period_end_date) 
+		DATEDIFF(DAY, cohort_start_date, observation_period_end_date)
 	} AS days_to_obs_end
 INTO #cohort_person
 FROM (
@@ -71,46 +71,65 @@ FROM (
 		MIN(cohort_end_date) AS cohort_end_date
 	FROM (
 }
-{@exposure_table == 'drug_era' } ? { 
-	SELECT person_id AS subject_id,
+{@exposure_table == 'drug_era' } ? {
+	SELECT exposure_table.person_id AS subject_id,
 		drug_concept_id AS cohort_definition_id,
 		drug_era_start_date AS cohort_start_date,
 		drug_era_end_date AS cohort_end_date
 	FROM  @exposure_database_schema.@exposure_table exposure_table
-	WHERE drug_concept_id IN (@target_id, @comparator_id)
-{@remove_duplicate_subjects} ? {
-		AND (SELECT COUNT(DISTINCT(drug_concept_id)) 
-			 FROM @exposure_database_schema.@exposure_table temp
-			 WHERE temp.person_id = exposure_table.person_id
-			 AND drug_concept_id IN (@target_id, @comparator_id)) = 1
-}	
+	{@remove_duplicate_subjects} ? {
+		INNER JOIN
+		(SELECT person_id,
+						COUNT(DISTINCT(drug_concept_id)) drug_count
+			 FROM @exposure_database_schema.@exposure_table
+			 WHERE drug_concept_id IN (@target_id, @comparator_id))
+			 GROUP BY person_id) temp
+		ON
+			exposure_table.person_id = temp.person_id
+		WHERE
+			temp.drug_count = 1
+	} : {
+		WHERE drug_concept_id IN (@target_id, @comparator_id)
+	}
 } : {
-	SELECT subject_id,
-{@cdm_version == "4"} ? {			
+	SELECT exposure_table.subject_id,
+{@cdm_version == "4"} ? {
 		cohort_concept_id AS cohort_definition_id,
-} : {			
+} : {
 		cohort_definition_id,
 }
 		cohort_start_date,
 		cohort_end_date
 	FROM @exposure_database_schema.@exposure_table exposure_table
-{@cdm_version == "4"} ? {	
-	WHERE cohort_concept_id IN (@target_id, @comparator_id)
-{@remove_duplicate_subjects} ? {
-		AND (SELECT COUNT(DISTINCT(cohort_concept_id)) 
-			 FROM @exposure_database_schema.@exposure_table temp
-			 WHERE temp.subject_id = exposure_table.subject_id
-			 AND cohort_concept_id IN (@target_id, @comparator_id)) = 1
-}
-} : {
-	WHERE cohort_definition_id IN (@target_id, @comparator_id)
-{@remove_duplicate_subjects} ? {
-		AND (SELECT COUNT(DISTINCT(cohort_definition_id)) 
-			 FROM @exposure_database_schema.@exposure_table temp
-			 WHERE temp.subject_id = exposure_table.subject_id
-			 AND cohort_definition_id IN (@target_id, @comparator_id)) = 1
-}	
-}
+	{@cdm_version == "4"} ? {
+		{@remove_duplicate_subjects} ? {
+			INNER JOIN
+			(SELECT subject_id, COUNT(DISTINCT(cohort_concept_id)) cohort_count
+			 FROM @exposure_database_schema.@exposure_table
+			 WHERE cohort_concept_id IN (@target_id, @comparator_id)
+		 	 GROUP BY subject_id) temp
+			ON
+				exposure_table.subject_id = temp.subject_id
+			WHERE
+				temp.cohort_count = 1
+		} : {
+			WHERE cohort_concept_id IN (@target_id, @comparator_id)
+		}
+	} : {
+		{@remove_duplicate_subjects} ? {
+			INNER JOIN
+			(SELECT subject_id, COUNT(DISTINCT(cohort_definition_id)) cohort_count
+			 FROM @exposure_database_schema.@exposure_table
+			 WHERE cohort_definition_id IN (@target_id, @comparator_id)
+		 	 GROUP BY subject_id) temp
+			ON
+				exposure_table.subject_id = temp.subject_id
+			WHERE
+				temp.cohort_count = 1
+		} : {
+			WHERE cohort_definition_id IN (@target_id, @comparator_id)
+		}
+	}
 }
 	) raw_cohorts
 {@first_only} ? {
@@ -122,6 +141,6 @@ INNER JOIN @cdm_database_schema.observation_period
 	ON subject_id = person_id
 WHERE cohort_start_date <= observation_period_end_date
 	AND cohort_start_date >= observation_period_start_date
-{@study_start_date != '' } ? {AND cohort_start_date >= CAST('@study_start_date' AS DATE) } 
+{@study_start_date != '' } ? {AND cohort_start_date >= CAST('@study_start_date' AS DATE) }
 {@study_end_date != '' } ? {AND cohort_start_date < CAST('@study_end_date' AS DATE) }
 {@washout_period != 0} ? {AND DATEDIFF(DAY, observation_period_start_date, cohort_start_date) >= @washout_period};

--- a/inst/sql/sql_server/CreateCohorts.sql
+++ b/inst/sql/sql_server/CreateCohorts.sql
@@ -1,5 +1,5 @@
 /************************************************************************
-@file GetCohorts.sql
+@file CreateCohorts.sql
 
 Copyright 2016 Observational Health Data Sciences and Informatics
 


### PR DESCRIPTION
Removed sub-query from where clause for remove_duplicates that would cause quadratic run-time.  On a large dataset such as SYNPUF this results in going from a very long running query to sub 5 seconds.

Fixed based on @schuemie comments on #50 