### PR TITLE
Fix to check install helper function

### DIFF
--- a/R/HelperFunctions.R
+++ b/R/HelperFunctions.R
@@ -202,8 +202,8 @@ constructEras <- function(connectionDetails,
 #' @export
 checkCmInstallation <- function(connectionDetails) {
   writeLines("Checking database connectivity")
-  conn <- connect(connectionDetails)
-  dbDisconnect(conn)
+  conn <- DatabaseConnector::connect(connectionDetails)
+  DatabaseConnector::disconnect(conn)
   writeLines("- Ok")
 
   writeLines("\nChecking large scale regression engine")


### PR DESCRIPTION
Received the error when attempting to use the checkCmInstallation method:

> Error in (function (classes, fdef, mtable)  : 
  unable to find an inherited method for function ‘dbDisconnect’ for signature ‘"Connection"’

Revised the code to use DatabaseConnector package instead of RJDBC. Please let me know if you have any concerns with this approach.