### PR TITLE
Tests for creating simulated data and handling edge cases in running multiple CM analysis

### DIFF
--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -33,6 +33,15 @@
 #' @export
 createCohortMethodDataSimulationProfile <- function(cohortMethodData) {
 
+  if (cohortMethodData$cohorts %>% count() %>% pull() == 0)
+    stop("Cohorts are empty")
+
+  if (cohortMethodData$covarites %>% count() %>% pull() == 0)
+    stop("Covariates are empty")
+
+  if (sum(cohortMethodData$cohorts %>% select(daysToCohortEnd) %>% pull()) == 0)
+    warning("Cohort data appears to be limited, check daysToCohortEnd which appears to be all zeros")
+
   ParallelLogger::logInfo("Computing covariate prevalence")
   # (Note: currently limiting to binary covariates)
   populationSize <- cohortMethodData$cohorts %>%

--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -36,10 +36,10 @@ createCohortMethodDataSimulationProfile <- function(cohortMethodData) {
   if (cohortMethodData$cohorts %>% count() %>% pull() == 0)
     stop("Cohorts are empty")
 
-  if (cohortMethodData$covarites %>% count() %>% pull() == 0)
+  if (cohortMethodData$covariates %>% count() %>% pull() == 0)
     stop("Covariates are empty")
 
-  if (sum(cohortMethodData$cohorts %>% select(daysToCohortEnd) %>% pull()) == 0)
+  if (sum(cohortMethodData$cohorts %>% select(.data$daysToCohortEnd) %>% pull()) == 0)
     warning("Cohort data appears to be limited, check daysToCohortEnd which appears to be all zeros")
 
   ParallelLogger::logInfo("Computing covariate prevalence")

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -1,0 +1,99 @@
+test_that("createCohortMethodDataSimulationProfile", {
+  covarSettings <- FeatureExtraction::createCovariateSettings(useDemographicsGender = TRUE,
+                                                              useDemographicsAge = TRUE,
+                                                              useDemographicsAgeGroup = TRUE,
+                                                              useDemographicsIndexMonth = TRUE,
+                                                              useDemographicsPriorObservationTime = TRUE,
+                                                              useDemographicsPostObservationTime = TRUE,
+                                                              useDemographicsTimeInCohort = TRUE,
+                                                              useDemographicsIndexYearMonth = TRUE,
+                                                              useMeasurementValueLongTerm = TRUE,
+                                                              useMeasurementValueMediumTerm = TRUE,
+                                                              useMeasurementValueShortTerm = TRUE,
+                                                              useMeasurementRangeGroupAnyTimePrior = TRUE,
+                                                              useMeasurementRangeGroupLongTerm = TRUE,
+                                                              useMeasurementRangeGroupMediumTerm = TRUE,
+                                                              useMeasurementRangeGroupShortTerm = TRUE,
+                                                              useObservationAnyTimePrior = TRUE,
+                                                              useObservationLongTerm = TRUE,
+                                                              useObservationMediumTerm = TRUE,
+                                                              useObservationShortTerm = TRUE,
+                                                              endDays = 180)
+
+  cohortMethodData <- getDbCohortMethodData(connectionDetails = connectionDetails,
+                                            cdmDatabaseSchema = "main",
+                                            exposureTable = "cohort",
+                                            outcomeTable = "cohort",
+                                            targetId = 1,
+                                            comparatorId = 2,
+                                            outcomeIds = c(3, 4),
+                                            cdmVersion = "5",
+                                            washoutPeriod = 183,
+                                            firstExposureOnly = TRUE,
+                                            removeDuplicateSubjects = TRUE,
+                                            restrictToCommonPeriod = TRUE,
+                                            maxCohortSize = 100000,
+                                            covariateSettings = covarSettings)
+
+
+  cohorts <- data.frame(cohortMethodData$cohorts)
+  cohorts$daysToCohortEnd <- rexp(nrow(cohorts), rate = 10)
+  cohortMethodData$cohorts <- cohorts
+
+  cohortDataSimulationProfile <- createCohortMethodDataSimulationProfile(cohortMethodData)
+
+  # Basic checks to see if output simulated data are meaninful
+  expect_s3_class(cohortDataSimulationProfile, "CohortDataSimulationProfile")
+  expect_true(cohortDataSimulationProfile$cohortEndRate > 0)
+  expect_true(cohortDataSimulationProfile$obsStartRate > 0)
+  expect_true(cohortDataSimulationProfile$obsEndRate > 0)
+
+})
+
+test_that("Test bad covariate data", {
+  covarSettings <- FeatureExtraction::createCovariateSettings(useDemographicsGender = TRUE)
+
+  cohortMethodData <- getDbCohortMethodData(connectionDetails = connectionDetails,
+                                            cdmDatabaseSchema = "main",
+                                            exposureTable = "cohort",
+                                            outcomeTable = "cohort",
+                                            targetId = 1,
+                                            comparatorId = 2,
+                                            outcomeIds = c(3, 4),
+                                            cdmVersion = "5",
+                                            washoutPeriod = 183,
+                                            firstExposureOnly = TRUE,
+                                            removeDuplicateSubjects = TRUE,
+                                            restrictToCommonPeriod = TRUE,
+                                            maxCohortSize = 100000,
+                                            covariateSettings = covarSettings)
+
+  expect_warning({
+    cohortDataSimulationProfile <- createCohortMethodDataSimulationProfile(cohortMethodData)
+  }, "Cohort data appears to be limited, check daysToCohortEnd which appears to be all zeros")
+
+
+  warnings <- capture_warnings({
+    cohortMethodData <- getDbCohortMethodData(connectionDetails = connectionDetails,
+                                              cdmDatabaseSchema = "main",
+                                              exposureTable = "cohort",
+                                              outcomeTable = "cohort",
+                                              targetId = 99,
+                                              comparatorId = 99,
+                                              outcomeIds = c(99, 99),
+                                              cdmVersion = "5",
+                                              washoutPeriod = 183,
+                                              firstExposureOnly = TRUE,
+                                              removeDuplicateSubjects = TRUE,
+                                              restrictToCommonPeriod = TRUE,
+                                              maxCohortSize = 100000,
+                                              covariateSettings = covarSettings)
+
+  })
+  expect_match(warnings, "Target and comparator cohorts are empty", all = FALSE)
+  expect_match(warnings, "Population is empty. No covariates were constructed", all = FALSE)
+  expect_error({
+    cohortDataSimulationProfile <- createCohortMethodDataSimulationProfile(cohortMethodData)
+  }, "Cohorts are empty")
+
+})


### PR DESCRIPTION
Collection of unit test additions including:
* Running multiple analyses with separable interaction terms and non-seperable interaction terms (computed by making entire population a single gender and defining a analysis to be based on gender)
* Checks on running multiple analysis with bad inputs
* Creating simulation profile
* Error/checks for creating simulation profile without covariates or cohorts
* Warning for limited cohort data that may not be useful in a simulation

Some warnings are still coming from upstream packages (mainly Andromeda/Cyclops) so warnings are checked with capture warnings.