### PR TITLE
Allow usage of devtools::load_all and devtools::test

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,4 +11,3 @@ compare_versions
 .github
 docs
 .idea
-sql

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^renv$
+^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 extras
@@ -8,3 +10,5 @@ deploy.sh
 compare_versions
 .github
 docs
+.idea
+sql

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/*.so
 src/*.dll
 /Debug
 standalone/build/*
+sql

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Suggests:
 	rmarkdown,
 	EmpiricalCalibration,
 	Eunomia,
-	withr
+	withr,
+	R.utils
 Remotes:
 	ohdsi/FeatureExtraction
 LinkingTo: Rcpp

--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -36,10 +36,10 @@ createCohortMethodDataSimulationProfile <- function(cohortMethodData) {
   if (cohortMethodData$cohorts %>% count() %>% pull() == 0)
     stop("Cohorts are empty")
 
-  if (cohortMethodData$covarites %>% count() %>% pull() == 0)
+  if (cohortMethodData$covariates %>% count() %>% pull() == 0)
     stop("Covariates are empty")
 
-  if (sum(cohortMethodData$cohorts %>% select(daysToCohortEnd) %>% pull()) == 0)
+  if (sum(cohortMethodData$cohorts %>% select(.data$daysToCohortEnd) %>% pull()) == 0)
     warning("Cohort data appears to be limited, check daysToCohortEnd which appears to be all zeros")
 
   ParallelLogger::logInfo("Computing covariate prevalence")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,9 @@
+# When devtools::load_all is run, create symbolic link for sql directory
+# Allows testing with devtools::test
+if (Sys.getenv("DEVTOOLS_LOAD") == "true") {
+  print("setting sql folder symobolic link")
+  packageRoot <- normalizePath(system.file("..", package = "CohortMethod"))
+  # Create symbolic link so code can be used in devtools::test()
+  R.utils::createLink(link = file.path(packageRoot, "sql"), system.file("sql", package = "CohortMethod"))
+  options("use.devtools.sql_shim" = TRUE)
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -5,4 +5,9 @@ Eunomia::createCohorts(connectionDetails)
 withr::defer({
   # Remove the Eunomia database:
   unlink(connectionDetails$server())
+  if (getOption("use.devtools.sql_shim", FALSE)){
+    # Remove symbolic link to sql folder created when devtools::test loads helpers
+    packageRoot <- normalizePath(system.file("..", package = "CohortMethod"))
+    unlink(file.path(packageRoot, "sql"), recursive = FALSE)
+  }
 }, testthat::teardown_env())


### PR DESCRIPTION
A solution to allow SqlRender to find sql files inside a package when `devtools::load_all` is called is to create a symbolic link at the package root.

When `devtools::load_all()` is called, any testthat helpers are loaded too, crucially this is done with the environment var "DEVTOOLS_LOAD" = "true".

This patch is from the develop branch and also includes tests written by @k-m-li for `stratifyByPs` and `createPs` to test checks.