### PR TITLE
getDbCohortMethodData unit-tests

### DIFF
--- a/R/DataLoadingSaving.R
+++ b/R/DataLoadingSaving.R
@@ -136,7 +136,7 @@ getDbCohortMethodData <- function(connectionDetails,
   checkmate::assertCharacter(exposureTable, len = 1, add = errorMessages)
   checkmate::assertCharacter(outcomeDatabaseSchema, len = 1, add = errorMessages)
   checkmate::assertCharacter(outcomeTable, len = 1, add = errorMessages)
-  checkmate::assertCharacter(cdmVersion, len = 1, add = errorMessages)
+  checkmate::assertCharacter(cdmVersion, len = 1, n.chars = 1, pattern = "^[5]$", add = errorMessages)
   checkmate::assertLogical(firstExposureOnly, len = 1, add = errorMessages)
   checkmate::assertChoice(removeDuplicateSubjects, c("keep all", "keep first", "remove all"), add = errorMessages)
   checkmate::assertLogical(restrictToCommonPeriod, len = 1, add = errorMessages)
@@ -145,12 +145,9 @@ getDbCohortMethodData <- function(connectionDetails,
   checkmate::assertList(covariateSettings, add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
 
-  if (is.null(studyStartDate)) {
-    studyStartDate <- ""
-  }
-  if (is.null(studyEndDate)) {
-    studyEndDate <- ""
-  }
+  dateCheck(studyStartDate)
+  dateCheck(studyEndDate)
+
   if (studyStartDate != "" &&
     regexpr("^[12][0-9]{3}[01][0-9][0-3][0-9]$", studyStartDate) == -1) {
     stop("Study start date must have format YYYYMMDD")
@@ -468,4 +465,21 @@ handleCohortCovariateBuilders <- function(covariateSettings,
     }
   }
   return(covariateSettings)
+}
+
+dateCheck <- function(date) {
+  if (date != "") {
+    tryCatch({
+      dateFormatted <- paste0(
+        substr(x = date, start = 1, stop = 4), "-",
+        substr(x = date, start = 5, stop = 6), "-",
+        substr(x = date, start = 7, stop = 8)
+      )
+
+      date <- as.Date(dateFormatted)
+    }, error = function(e) {
+      stop(sprintf("Date: %s (%s) is not valid", date, dateFormatted))
+    })
+    checkmate::assertDate(date, lower = "1000-01-01", upper = "2999-12-31")
+  }
 }

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -92,11 +92,13 @@ uploadExportedResults <- function(connectionDetails,
   ensureInstalled("ResultModelManager")
   connection <- DatabaseConnector::connect(connectionDetails)
 
-  # tryCatch({
-  #   on.exit(DatabaseConnector::disconnect(connection), add = TRUE, after = TRUE)
-  # }, error = function(e) {
-  #   message(e)
-  # })
+  withr::defer({
+    tryCatch({
+      DatabaseConnector::disconnect(connection)
+    }, error = function(e) {
+      message(e)
+    })
+  })
 
   if (!append) {
     # Create tables
@@ -142,11 +144,13 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  # tryCatch({
-  #   on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
-  # }, error = function(e) {
-  #   message(e)
-  # })
+  withr::defer({
+    tryCatch({
+      unlink(databaseIdentifierFile)
+    }, error = function(e) {
+      message(e)
+    })
+  })
   # Upload results
   ResultModelManager::uploadResults(
     connection = connection,

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -137,7 +137,9 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
+  try({
+    on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
+  })
 
   # Upload results
   ResultModelManager::uploadResults(

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -137,7 +137,7 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  on.exit(unlink(databaseIdentifierFile), add = TRUE)
+  on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
 
   # Upload results
   ResultModelManager::uploadResults(

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -137,9 +137,10 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  try({
-    on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
-  })
+  try(
+    expr = {on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)},
+    silent = TRUE
+  )
 
   # Upload results
   ResultModelManager::uploadResults(

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -91,7 +91,12 @@ uploadExportedResults <- function(connectionDetails,
 
   ensureInstalled("ResultModelManager")
   connection <- DatabaseConnector::connect(connectionDetails)
-  on.exit(DatabaseConnector::disconnect(connection), add = TRUE, after = TRUE)
+
+  tryCatch({
+    on.exit(DatabaseConnector::disconnect(connection), add = TRUE, after = TRUE)
+  }, error = function(e) {
+    message(e)
+  })
 
   if (!append) {
     # Create tables
@@ -137,7 +142,11 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
+  tryCatch({
+    on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
+  }, error = function(e) {
+    message(e)
+  })
   # Upload results
   ResultModelManager::uploadResults(
     connection = connection,

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -91,7 +91,7 @@ uploadExportedResults <- function(connectionDetails,
 
   ensureInstalled("ResultModelManager")
   connection <- DatabaseConnector::connect(connectionDetails)
-  on.exit(DatabaseConnector::disconnect(connection))
+  on.exit(DatabaseConnector::disconnect(connection), add = TRUE, after = TRUE)
 
   if (!append) {
     # Create tables
@@ -137,11 +137,7 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  try(
-    expr = {on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)},
-    silent = TRUE
-  )
-
+  on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
   # Upload results
   ResultModelManager::uploadResults(
     connection = connection,

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -92,11 +92,11 @@ uploadExportedResults <- function(connectionDetails,
   ensureInstalled("ResultModelManager")
   connection <- DatabaseConnector::connect(connectionDetails)
 
-  tryCatch({
-    on.exit(DatabaseConnector::disconnect(connection), add = TRUE, after = TRUE)
-  }, error = function(e) {
-    message(e)
-  })
+  # tryCatch({
+  #   on.exit(DatabaseConnector::disconnect(connection), add = TRUE, after = TRUE)
+  # }, error = function(e) {
+  #   message(e)
+  # })
 
   if (!append) {
     # Create tables
@@ -142,11 +142,11 @@ uploadExportedResults <- function(connectionDetails,
     dropTableIfExists = FALSE,
     createTable = !append
   )
-  tryCatch({
-    on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
-  }, error = function(e) {
-    message(e)
-  })
+  # tryCatch({
+  #   on.exit(unlink(databaseIdentifierFile), add = TRUE, after = TRUE)
+  # }, error = function(e) {
+  #   message(e)
+  # })
   # Upload results
   ResultModelManager::uploadResults(
     connection = connection,

--- a/tests/testthat/test-eunomia.R
+++ b/tests/testthat/test-eunomia.R
@@ -19,6 +19,12 @@ test_that("Check installation", {
 
 test_that("Multiple analyses", {
   outputFolder <- tempfile(pattern = "cmData")
+  withr::defer(
+    {
+      unlink(outputFolder, recursive = TRUE)
+    },
+    testthat::teardown_env()
+  )
 
   tcos1 <- createTargetComparatorOutcomes(
     targetId = 1,
@@ -295,13 +301,6 @@ test_that("Multiple analyses", {
       targetComparatorOutcomesList = targetComparatorOutcomesList <- list(tcos1, tcos2, "brokenObject")
     )
   })
-
-  withr::defer(
-    {
-      unlink(outputFolder, recursive = TRUE)
-    },
-    testthat::teardown_env()
-  )
 })
 
 

--- a/tests/testthat/test-eunomia.R
+++ b/tests/testthat/test-eunomia.R
@@ -19,12 +19,6 @@ test_that("Check installation", {
 
 test_that("Multiple analyses", {
   outputFolder <- tempfile(pattern = "cmData")
-  withr::defer(
-    {
-      unlink(outputFolder, recursive = TRUE)
-    },
-    testthat::teardown_env()
-  )
 
   tcos1 <- createTargetComparatorOutcomes(
     targetId = 1,
@@ -301,6 +295,13 @@ test_that("Multiple analyses", {
       targetComparatorOutcomesList = targetComparatorOutcomesList <- list(tcos1, tcos2, "brokenObject")
     )
   })
+
+  withr::defer(
+    {
+      unlink(outputFolder, recursive = TRUE)
+    },
+    testthat::teardown_env()
+  )
 })
 
 

--- a/tests/testthat/test-getDbCohortMethodData.R
+++ b/tests/testthat/test-getDbCohortMethodData.R
@@ -1,0 +1,706 @@
+library(CohortMethod)
+library(testthat)
+
+dim_tbl_dbi <- function(x) {
+  return(c(x %>%
+    summarise(n = n()) %>%
+    pull(),
+    ncol(x)
+  ))
+}
+
+nsaids <- c(1118084, 1124300)
+
+covSettings <- createDefaultCovariateSettings(
+  excludedCovariateConceptIds = nsaids,
+  addDescendantsToExclude = TRUE
+)
+
+test_that("CohortMethodData table dimension check", {
+  cmd <<- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings
+  )
+
+  # Dims of CohortMethodData tables
+  expect_identical(dim_tbl_dbi(cmd$analysisRef), c(24L, 7L))
+  expect_identical(dim_tbl_dbi(cmd$cohorts), c(2630L, 8L))
+  expect_identical(dim_tbl_dbi(cmd$covariateRef), c(389L, 4L))
+  expect_identical(dim_tbl_dbi(cmd$covariates), c(26923L, 3L))
+  expect_identical(dim_tbl_dbi(cmd$outcomes), c(3109L, 3L))
+})
+
+test_that("studyStartDate", {
+  # pattern: ^[12][0-9]{3}[01][0-9][0-3][0-9]
+  # min: 1000-00-00
+  # max: 2999-19-39
+
+  ## "02032022" (0203-20-22) ----
+  expect_error(
+    expect_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        studyStartDate = "02032022"
+      ),
+      "Study start date must have format YYYYMMDD"
+    )
+  )
+
+  ## "10000000" (1000-00-00) ----
+  expect_error(
+    expect_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        studyStartDate = "10000000"
+      ) # invalid date
+    )
+  )
+
+  ## "09991231" (0999-12-31) ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyStartDate = "09991231"
+    ) # "date out of bounds ('10000101' - '29991231')"
+  )
+
+  ## "29991939" (2999-19-39) ----
+  expect_error(
+    expect_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        studyStartDate = "29991939"
+      ) # invalid date
+    )
+  )
+
+  ## "29991940" (2999-19-40) ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyStartDate = "29991940"
+    ) # invalid date
+  )
+})
+
+test_that("studyEndDate", {
+  # pattern: ^[12][0-9]{3}[01][0-9][0-3][0-9]
+  # min: 1000-00-00
+  # max: 2999-19-39
+
+  ## "02032022" (0203-20-22) ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = "02032022"
+    ),
+    "Study end date must have format YYYYMMDD"
+  )
+
+  ## "10000000" (1000-00-00) ----
+  expect_error(
+    expect_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        studyEndDate = "10000000"
+      )# "invalid date"
+    )
+  )
+
+  ## "09991231" (0999-12-31) ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = "09991231"
+    ) # "date out of bounds ('10000101' - '29991231')"
+  )
+
+  ## "29991939" (2999-19-39) ----
+  expect_error(
+    expect_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        studyEndDate = "29991939"
+      )
+    ) # "invalid date"
+  )
+
+  ## "29991940" (2999-19-40) ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = "29991940"
+    ) # "date out of bounds ('10000101' - '29991231')"
+  )
+})
+
+test_that("tempEmulationSchema", {
+  ## default ----
+  expect_no_error(
+    expect_no_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        # In Eunomia
+        tempEmulationSchema = "main"
+      )
+    )
+  )
+  ## comments ----
+  # Throws:
+  # Warning message:
+  #   The 'oracleTempSchema' argument is deprecated. Use 'tempEmulationSchema' instead.
+  # on first run
+})
+
+
+test_that("cdmVersion", {
+  ## default ----
+  expect_no_error(
+    expect_no_warning(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        cdmVersion = "5"
+      )
+    )
+  )
+
+  ## "9" ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      cdmVersion = "9"
+    ) # invalid cdmVersion
+  )
+
+  ## "madeUpVersion" ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      cdmVersion = "madeUpVersion"
+    ) # invalid cdmVersion
+  )
+  ## comments ----
+  # Expected error; i.e. "cdmVersion not supported"
+  # Current checks: len = 1, is.character
+  # Regex: ^[5]$
+  # Regex multiple version: ^[456]$
+})
+
+
+test_that("firstExposureOnly", {
+  ## default ----
+  res1 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    firstExposureOnly = FALSE
+  )
+
+  meta1 <- attr(res1, "metaData")
+  expect_identical(nrow(meta1$attrition), 1L)
+
+  ## TRUE ----
+  res2 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    firstExposureOnly = TRUE
+  )
+
+  meta2 <- attr(res2, "metaData")
+  expect_true("First exp. only" %in% meta2$attrition$description)
+  expect_identical(nrow(meta2$attrition), 2L)
+
+  ## "TRUE" ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      firstExposureOnly = "TRUE"
+    )
+  )
+})
+
+test_that("removeDuplicateSubjects", {
+  ## default: "keep all" ----
+  res1 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    removeDuplicateSubjects = "keep all"
+  )
+
+  meta1 <- attr(res1, "metaData")
+  expect_identical(nrow(meta1$attrition), 1L)
+
+  ## "keep first" ----
+  res2 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    removeDuplicateSubjects = "keep first"
+  )
+
+  meta2 <- attr(res2, "metaData")
+  expect_identical(nrow(meta2$attrition), 2L)
+  expect_true("First cohort only" %in% meta2$attrition$description)
+
+  ## "remove all" ----
+  res3 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    removeDuplicateSubjects = "remove all"
+  )
+
+  meta3 <- attr(res3, "metaData")
+  expect_identical(nrow(meta3$attrition), 2L)
+  expect_true("Removed subs in both cohorts" %in% meta3$attrition$description)
+
+  ## "do nothing" ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      removeDuplicateSubjects = "do nothing"
+    )
+  )
+})
+
+test_that("restrictToCommonPeriod", {
+  ## default: FALSE ----
+  res1 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    restrictToCommonPeriod = FALSE
+  )
+
+  meta1 <- attr(res1, "metaData")
+  expect_equal(meta1$populationSize, 2630)
+  expect_equal(dim_tbl_dbi(res1$outcomes)[1], 3109)
+  expect_equal(dim_tbl_dbi(res1$covariates)[1], 26923)
+
+  ## TRUE ----
+  res2 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    restrictToCommonPeriod = TRUE
+  )
+
+  meta2 <- attr(res2, "metaData")
+  expect_equal(meta2$populationSize, 2627)
+  expect_equal(dim_tbl_dbi(res2$outcomes)[1], 3106)
+  expect_equal(dim_tbl_dbi(res2$covariates)[1], 26893)
+
+  ## "TRUE" ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      restrictToCommonPeriod = "TRUE"
+    )
+  )
+})
+
+test_that("washoutPeriod", {
+  ## default: 0 ----
+  res1 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    washoutPeriod = 0
+  )
+
+  meta1 <- attr(res1, "metaData")
+  expect_equal(meta1$populationSize, 2630)
+
+  ## 150000 ----
+  res2 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    washoutPeriod = 15000
+  )
+
+  meta2 <- attr(res2, "metaData")
+  expect_equal(meta2$populationSize, 681)
+
+  ## 17000 ----
+  res3 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    washoutPeriod = 17000
+  )
+
+  meta3 <- attr(res3, "metaData")
+  expect_equal(meta3$populationSize, 3)
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      washoutPeriod = -1
+    ),
+    ">= 0"
+  )
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      washoutPeriod = "1"
+    ),
+    "not 'character'"
+  )
+
+  expect_no_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      washoutPeriod = 1L
+    )
+  )
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      washoutPeriod = 1.3
+    ), "not 'double'"
+  )
+})
+
+test_that("maxCohortSize", {
+  ## default: 0 ----
+  res1 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    maxCohortSize = 0
+  )
+
+  meta1 <- attr(res1, "metaData")
+  expect_equal(meta1$populationSize, 2630)
+
+  ## 100 ----
+  res2 <- getDbCohortMethodData(
+    connectionDetails = connectionDetails,
+    cdmDatabaseSchema = "main",
+    targetId = 1,
+    comparatorId = 2,
+    outcomeIds = c(3, 4),
+    exposureDatabaseSchema = "main",
+    outcomeDatabaseSchema = "main",
+    exposureTable = "cohort",
+    outcomeTable = "cohort",
+    covariateSettings = covSettings,
+    maxCohortSize = 100
+  )
+
+  meta2 <- attr(res2, "metaData")
+  expect_equal(meta2$populationSize, 200)
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      maxCohortSize = -1
+    ),
+    ">= 0"
+  )
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      maxCohortSize = "100"
+    ),
+    "not 'character'"
+  )
+})

--- a/tests/testthat/test-getDbCohortMethodData.R
+++ b/tests/testthat/test-getDbCohortMethodData.R
@@ -17,7 +17,7 @@ covSettings <- createDefaultCovariateSettings(
 )
 
 test_that("CohortMethodData table dimension check", {
-  cmd <<- getDbCohortMethodData(
+  cmd <- getDbCohortMethodData(
     connectionDetails = connectionDetails,
     cdmDatabaseSchema = "main",
     targetId = 1,
@@ -43,8 +43,8 @@ test_that("studyStartDate", {
   # min: 1000-00-00
   # max: 2999-19-39
 
-  ## "02032022" (0203-20-22) ----
-  expect_error(
+  ## 20230822 (2023-08-22) ----
+  expect_no_error(
     expect_warning(
       getDbCohortMethodData(
         connectionDetails = connectionDetails,
@@ -57,29 +57,64 @@ test_that("studyStartDate", {
         exposureTable = "cohort",
         outcomeTable = "cohort",
         covariateSettings = covSettings,
-        studyStartDate = "02032022"
-      ),
-      "Study start date must have format YYYYMMDD"
+        studyStartDate = "20230822"
+      )
     )
+  )
+
+  ## "" ("") ----
+  expect_no_error(
+    suppressWarnings(
+      getDbCohortMethodData(
+        connectionDetails = connectionDetails,
+        cdmDatabaseSchema = "main",
+        targetId = 1,
+        comparatorId = 2,
+        outcomeIds = c(3, 4),
+        exposureDatabaseSchema = "main",
+        outcomeDatabaseSchema = "main",
+        exposureTable = "cohort",
+        outcomeTable = "cohort",
+        covariateSettings = covSettings,
+        studyStartDate = ""
+      )
+    )
+  )
+
+  ## "02032022" (0203-20-22) ----
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyStartDate = "02032022"
+    ),
+    "Date: .+ is not valid"
   )
 
   ## "10000000" (1000-00-00) ----
   expect_error(
-    expect_warning(
-      getDbCohortMethodData(
-        connectionDetails = connectionDetails,
-        cdmDatabaseSchema = "main",
-        targetId = 1,
-        comparatorId = 2,
-        outcomeIds = c(3, 4),
-        exposureDatabaseSchema = "main",
-        outcomeDatabaseSchema = "main",
-        exposureTable = "cohort",
-        outcomeTable = "cohort",
-        covariateSettings = covSettings,
-        studyStartDate = "10000000"
-      ) # invalid date
-    )
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyStartDate = "10000000"
+    ),
+    "Date: .+ is not valid"
   )
 
   ## "09991231" (0999-12-31) ----
@@ -96,26 +131,25 @@ test_that("studyStartDate", {
       outcomeTable = "cohort",
       covariateSettings = covSettings,
       studyStartDate = "09991231"
-    ) # "date out of bounds ('10000101' - '29991231')"
+    ), "Date must be >= 1000-01-01"
   )
 
   ## "29991939" (2999-19-39) ----
   expect_error(
-    expect_warning(
-      getDbCohortMethodData(
-        connectionDetails = connectionDetails,
-        cdmDatabaseSchema = "main",
-        targetId = 1,
-        comparatorId = 2,
-        outcomeIds = c(3, 4),
-        exposureDatabaseSchema = "main",
-        outcomeDatabaseSchema = "main",
-        exposureTable = "cohort",
-        outcomeTable = "cohort",
-        covariateSettings = covSettings,
-        studyStartDate = "29991939"
-      ) # invalid date
-    )
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyStartDate = "29991939"
+    ),
+    "Date: .+ is not valid"
   )
 
   ## "29991940" (2999-19-40) ----
@@ -132,7 +166,25 @@ test_that("studyStartDate", {
       outcomeTable = "cohort",
       covariateSettings = covSettings,
       studyStartDate = "29991940"
-    ) # invalid date
+    ),
+    "Date: .+ is not valid"
+  )
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyStartDate = "30000101"
+    ),
+    "Date must be <= 2999-12-31"
   )
 })
 
@@ -140,6 +192,40 @@ test_that("studyEndDate", {
   # pattern: ^[12][0-9]{3}[01][0-9][0-3][0-9]
   # min: 1000-00-00
   # max: 2999-19-39
+
+  ## 20230822 (2023-08-22) ----
+  expect_no_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = "20230822"
+    )
+  )
+
+  ## "" ("") ----
+  expect_no_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = ""
+    )
+  )
 
   ## "02032022" (0203-20-22) ----
   expect_error(
@@ -155,7 +241,8 @@ test_that("studyEndDate", {
       outcomeTable = "cohort",
       covariateSettings = covSettings,
       studyEndDate = "02032022"
-    )
+    ),
+    "Date: .+ is not valid"
   )
 
   ## "10000000" (1000-00-00) ----
@@ -173,7 +260,8 @@ test_that("studyEndDate", {
         outcomeTable = "cohort",
         covariateSettings = covSettings,
         studyEndDate = "10000000"
-      )# "invalid date"
+      ),
+      "Date: .+ is not valid"
     )
   )
 
@@ -191,26 +279,26 @@ test_that("studyEndDate", {
       outcomeTable = "cohort",
       covariateSettings = covSettings,
       studyEndDate = "09991231"
-    ) # "date out of bounds ('10000101' - '29991231')"
+    ),
+    "Date must be >= 1000-01-01"
   )
 
   ## "29991939" (2999-19-39) ----
   expect_error(
-    expect_warning(
-      getDbCohortMethodData(
-        connectionDetails = connectionDetails,
-        cdmDatabaseSchema = "main",
-        targetId = 1,
-        comparatorId = 2,
-        outcomeIds = c(3, 4),
-        exposureDatabaseSchema = "main",
-        outcomeDatabaseSchema = "main",
-        exposureTable = "cohort",
-        outcomeTable = "cohort",
-        covariateSettings = covSettings,
-        studyEndDate = "29991939"
-      )
-    ) # "invalid date"
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = "29991939"
+    ),
+    "Date: .+ is not valid"
   )
 
   ## "29991940" (2999-19-40) ----
@@ -227,14 +315,32 @@ test_that("studyEndDate", {
       outcomeTable = "cohort",
       covariateSettings = covSettings,
       studyEndDate = "29991940"
-    ) # "date out of bounds ('10000101' - '29991231')"
+    ),
+    "Date: .+ is not valid"
+  )
+
+  expect_error(
+    getDbCohortMethodData(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = "main",
+      targetId = 1,
+      comparatorId = 2,
+      outcomeIds = c(3, 4),
+      exposureDatabaseSchema = "main",
+      outcomeDatabaseSchema = "main",
+      exposureTable = "cohort",
+      outcomeTable = "cohort",
+      covariateSettings = covSettings,
+      studyEndDate = "30000101"
+    ),
+    "Date must be <= 2999-12-31"
   )
 })
 
 test_that("tempEmulationSchema", {
   ## default ----
   expect_no_error(
-    # expect_no_warning(
+    suppressWarnings(
       getDbCohortMethodData(
         connectionDetails = connectionDetails,
         cdmDatabaseSchema = "main",
@@ -249,7 +355,7 @@ test_that("tempEmulationSchema", {
         # In Eunomia
         tempEmulationSchema = "main"
       )
-    # )
+    )
   )
   ## comments ----
   # Throws:

--- a/tests/testthat/test-getDbCohortMethodData.R
+++ b/tests/testthat/test-getDbCohortMethodData.R
@@ -155,8 +155,7 @@ test_that("studyEndDate", {
       outcomeTable = "cohort",
       covariateSettings = covSettings,
       studyEndDate = "02032022"
-    ),
-    "Study end date must have format YYYYMMDD"
+    )
   )
 
   ## "10000000" (1000-00-00) ----
@@ -235,7 +234,7 @@ test_that("studyEndDate", {
 test_that("tempEmulationSchema", {
   ## default ----
   expect_no_error(
-    expect_no_warning(
+    # expect_no_warning(
       getDbCohortMethodData(
         connectionDetails = connectionDetails,
         cdmDatabaseSchema = "main",
@@ -250,7 +249,7 @@ test_that("tempEmulationSchema", {
         # In Eunomia
         tempEmulationSchema = "main"
       )
-    )
+    # )
   )
   ## comments ----
   # Throws:


### PR DESCRIPTION
I've added dedicated unit-tests for `getDbCohortMethodData()`. Each parameter of `getDbCohortMethodDate()` has a dedicated set of tests.

I've also made the following changes in the existing code:

1. **studyStartDate**/**studyEndDate**
  a. Added a function `dateCheck()` to check if a date is valid to replace the regex approach. The old regex approach allowed for non-existing dates like `"20231736"` (2023-17-36).
  b. Removed the `if (is.null())` checks, as `studyStartDate` and `studyEndDate` will never equal `NULL`, because of the checkmate assertion.
2. **cdmVersion**
  Updated the assertion on `cdmVersion`, the old check allowed for any character of any length.
3. `on.exit()` in `uploadExportedResults()`
  Wrapped the `unlink()` and `disconnect()` calls in `withr::defer()` and `tryCatch()`, as the following error kept showing up on Ubuntu when running R-CMD-Check in the actions, when running `test-eunomia.R`:
```
Error in `uploadExportedResults(connectionDetails = connectionDetails, 
      databaseSchema = "main", append = append, exportFolder = exportFolder, 
      cohorts = cohorts)`: object 'databaseIdentifierFile' not found
```
and
```
Error in `uploadExportedResults(connectionDetails = connectionDetails, 
    databaseSchema = "main", append = append, exportFolder = exportFolder, 
    cohorts = cohorts)`: object 'connection' not found
```
I suspect that both `connection` and `databaseIdentifierFile` are already cleaned up before `unlink(databaseIdentifierFile)` and `disconnect(connection)` get to actually run on Ubuntu. I've tried playing around with `on.exit(add, after)` as well, but that didn't seem to be working either.
