### PR TITLE
Handle empty attrition before downsampling

### DIFF
--- a/R/DataLoadingSaving.R
+++ b/R/DataLoadingSaving.R
@@ -292,7 +292,7 @@ downSample <- function(attrition,
                        tempEmulationSchema,
                        targetId,
                        maxCohortSize) {
-  if (maxCohortSize == 0) {
+  if (maxCohortSize == 0 || length(attrition$targetPersons) == 0) {
     return(FALSE)
   } else {
     sampled <- FALSE


### PR DESCRIPTION
Aims to fix #195 
